### PR TITLE
Original file name when submitting via distributed

### DIFF
--- a/utils/dist.py
+++ b/utils/dist.py
@@ -22,6 +22,7 @@ CUCKOO_ROOT = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..")
 sys.path.append(CUCKOO_ROOT)
 
 from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.utils import store_temp_file
 from lib.cuckoo.core.database import Database, TASK_COMPLETED, TASK_REPORTED, TASK_RUNNING
 
 # ElasticSearch not included, as it not officially maintained
@@ -647,9 +648,7 @@ class TaskRootApi(TaskBaseApi):
         args = self._parser.parse_args()
         f = request.files["file"]
 
-        fd, path = tempfile.mkstemp(dir=app.config["SAMPLES_DIRECTORY"])
-        f.save(path)
-        os.close(fd)
+        path = store_temp_file(f.read(), f.filename, path=app.config["SAMPLES_DIRECTORY"])
 
         task = Task(path=path, **args)
         db.session.add(task)

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -22,7 +22,6 @@ CUCKOO_ROOT = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..")
 sys.path.append(CUCKOO_ROOT)
 
 from lib.cuckoo.common.config import Config
-from lib.cuckoo.common.utils import store_temp_file
 from lib.cuckoo.core.database import Database, TASK_COMPLETED, TASK_REPORTED, TASK_RUNNING
 
 # ElasticSearch not included, as it not officially maintained
@@ -648,7 +647,9 @@ class TaskRootApi(TaskBaseApi):
         args = self._parser.parse_args()
         f = request.files["file"]
 
-        path = store_temp_file(f.read(), f.filename, path=app.config["SAMPLES_DIRECTORY"])
+        fd, path = tempfile.mkstemp(dir=app.config["SAMPLES_DIRECTORY"])
+        f.save(path)
+        os.close(fd)
 
         task = Task(path=path, **args)
         db.session.add(task)


### PR DESCRIPTION
Very simple, use original file name instead of a randomly generated one by mkstemp.

![foo](https://cloud.githubusercontent.com/assets/673857/16592142/27881f70-42d7-11e6-8cfc-08ee55371af0.png)
