### PR TITLE
Distributed submission from web interface

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -140,6 +140,7 @@ registry = no
 mutexes = no
 
 [distributed]
+enabled = yes
 remove_task_on_slave = no
 # Must be the same on all slaves
 slave_api_port = 8090


### PR DESCRIPTION
1. conf/reporting [distributed] added enabled field, without causes web errors here compare/views.py:20 
2. dist.py now checks the main_db for new added tasks in a state PENDING, if the main_task_id is not in the distributed database, it copies the task over and adds it to the dist database. The task is then assigned and so on. 

Q? Technically adding to the distributed database should also show up tasks on the pending table before they are run. 

Next TODO:
- submission of tasks to the node only if the node has the tags required.
- tasks submitted to distributed API get added to main_db in PENDING state.
- show what node the task is executing on in the 'Recent' web page table after status? 
- ...