### PR TITLE
Makes LIKE tag matching more precise to avoid confusion

### DIFF
--- a/utils/dist.py
+++ b/utils/dist.py
@@ -342,7 +342,7 @@ class StatusThread(threading.Thread):
 
         # Submit appropriate tasks to node
         for task in q.limit(MINIMUMQUEUE).all():
-           node.submit_task(task)
+            node.submit_task(task)
 
     def do_mongo(self, mongo_report, behaviour_report, mongo_db, t, node):
 


### PR DESCRIPTION
==> LIKE can cause tags like `Win_7` to be submitted to a node that only has a tag `Win_7_x64`. By searching for `Win_7,` this submission is avoided.
==> Tasks that are submitted via distributed API get instantly added to Web interface in the Pending section.
