### PR TITLE
VM and Slave control from dist.py

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -483,6 +483,21 @@ class Database(object):
             session.close()
 
     @classlock
+    def delete_machine(self, name):
+        """Delete a single machine entry from DB."""
+
+        session = self.Session()
+        try:
+            session.query(Machine).filter_by(name=name).delete()
+            session.commit()
+        except SQLAlchemyError as e:
+            log.debug("Database error deleting machine: {0}".format(e))
+            session.rollback()
+        finally:
+            session.close()
+
+
+    @classlock
     def add_machine(self, name, label, ip, platform, tags, interface,
                     snapshot, resultserver_ip, resultserver_port):
         """Add a guest machine.

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -488,10 +488,12 @@ class Database(object):
 
         session = self.Session()
         try:
-            session.query(Machine).filter_by(name=name).delete()
+            machine = session.query(Machine).filter_by(name=name).first()
+            session.delete(machine)
             session.commit()
+            return "success"
         except SQLAlchemyError as e:
-            log.debug("Database error deleting machine: {0}".format(e))
+            log.info("Database error deleting machine: {0}".format(e))
             session.rollback()
         finally:
             session.close()

--- a/utils/api.py
+++ b/utils/api.py
@@ -580,6 +580,17 @@ def machines_list():
 
     return jsonize(response)
 
+@route("/machines/delete/<machine_name>", method="GET")
+@route("/v1/machines/delete/<machine_name>", method="GET")
+def machines_delete(machine_name):
+    response = {}
+
+    machines = db.delete_machine(machine_name)
+
+    response["error"] = False
+    response["data"]  = "Deleted machine %s" % machine_name
+    return jsonize(response)
+
 @route("/cuckoo/status", method="GET")
 @route("/v1/cuckoo/status", method="GET")
 def cuckoo_status():

--- a/utils/api.py
+++ b/utils/api.py
@@ -585,10 +585,11 @@ def machines_list():
 def machines_delete(machine_name):
     response = {}
 
-    machines = db.delete_machine(machine_name)
+    status = db.delete_machine(machine_name)
 
-    response["error"] = False
-    response["data"]  = "Deleted machine %s" % machine_name
+    response["status"] = status
+    if status == "success":
+        response["data"]  = "Deleted machine %s" % machine_name
     return jsonize(response)
 
 @route("/cuckoo/status", method="GET")

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -214,8 +214,10 @@ class Node(db.Model):
 
         if jdec.decode(r.text)["status"] == "success":
             log.info("[Node %s] %s " % (self.name, jdec.decode(r.text)["data"]) )
+            return True
         else:
             log.info("[Node %s] Could not delete VM: %s" % (self.name, name) )
+            return False
 
     
 
@@ -956,11 +958,13 @@ def delete_vm_on_node(app, node_name, vm_name):
         if not vm:
             log.error("The selected VM does not exist")
             return
-        # delete vm in dist db
-        vm   = Machine.query.filter_by(name=vm_name, node_id=node.id).delete()
-        db.session.commit()
 
-        node.delete_machine(vm_name)
+        status = node.delete_machine(vm_name)
+
+        if status:
+            # delete vm in dist db
+            vm   = Machine.query.filter_by(name=vm_name, node_id=node.id).delete()
+            db.session.commit()
 
 def create_app(database_connection):
     app = Flask("Distributed Cuckoo")

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -212,10 +212,10 @@ class Node(db.Model):
             abort(404,
                   message="Cuckoo failed machine deletion (%s): %s" % (self.name, e))
 
-        if not jdec.decode(r.text)["error"]:
-            log.info("[Node %s]" % self.name, jdec.decode(r.text)["data"])
+        if jdec.decode(r.text)["status"] == "success":
+            log.info("[Node %s] %s " % (self.name, jdec.decode(r.text)["data"]) )
         else:
-            log.info("[Node %s] Could not delete VM: %s" % self.name, name )
+            log.info("[Node %s] Could not delete VM: %s" % (self.name, name) )
 
     
 


### PR DESCRIPTION
Update list of VM's on slave with:
./dist.py --node NAME

Allows deletion of vm on slave, useful for VM maintenance, via:
./dist.py --node NAME --delete-vm VM_NAME

Node fast enable and disable:
./dist.py --node NAME [--enable | --disable]

To have VM's run on slave that you have removed, at the moment you need to restart cuckoo.py. Hence first disable that node, so no more tasks get submitted. Wait for tasks to finish executing on VM's and restart cuckoo. 